### PR TITLE
fix: force push changes to dev branch after updating version in Cargo…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,10 +63,10 @@ jobs:
             # Use sed to update version in Cargo.toml
             sed -i "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" Cargo.toml
             
-            # Commit and push changes
+            # Commit and force push changes
             git add Cargo.toml
             git commit -m "chore: add dev suffix to version ${NEW_VERSION}"
-            git push origin dev
+            git push --force origin HEAD:dev
           fi
 
       - name: Remove dev suffix and bump version


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/release.yaml` file to modify the way changes are pushed to the `dev` branch.
